### PR TITLE
Bugfix: the type of the pathParams was incorrectly set to QueryParam.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.1] - 2019-08-07
+- Bugfix the type of the pathParams was incorrectly set to QueryParam
+  in the urlBuilder. Now has its own generic called PathParam.
+
 ## [2.2.0] - 2019-07-29
 - Removed QueryParams as a model now expecting the user to provide
   them via generics instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@42.nl/react-url",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5952,9 +5952,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@42.nl/react-url",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "This library makes it easy to define URL's and type them with flow.",
   "files": [
     "lib"
@@ -53,7 +53,7 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "ts-jest": "24.0.0",
-    "typescript": "3.3.3333"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "start": "jest test --watch",

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -2,9 +2,9 @@ import { Url } from './models';
 import { pathParamsBuilder } from './pathParamsBuilder';
 import { queryParamsBuilder } from './queryParamsBuilder';
 
-export interface UrlBuilderOptions<QueryParams> {
+export interface UrlBuilderOptions<PathParams, QueryParams> {
   url: Url;
-  pathParams?: QueryParams;
+  pathParams?: PathParams;
   queryParams?: QueryParams;
   defaultQueryParams?: QueryParams;
 }
@@ -50,7 +50,7 @@ export interface UrlBuilderOptions<QueryParams> {
  * @param {Object} options.queryParams
  * @param {Object} options.defaultQueryParams
  */
-export function urlBuilder<QueryParams>(options: UrlBuilderOptions<QueryParams>): Url {
+export function urlBuilder<PathParams, QueryParams>(options: UrlBuilderOptions<PathParams, QueryParams>): Url {
   const { url, pathParams, queryParams, defaultQueryParams } = options;
 
   // If we have no pathParams and queryParams return the abstract url.

--- a/tests/urlBuilder.test.ts
+++ b/tests/urlBuilder.test.ts
@@ -1,4 +1,5 @@
 import { urlBuilder } from '../src/urlBuilder';
+import { Url } from '../src/models';
 
 describe('urlBuilder', () => {
   it('should know how to return abstract urls', () => {
@@ -36,4 +37,41 @@ describe('urlBuilder', () => {
 
     expect(urlBuilder({ url, pathParams, queryParams, defaultQueryParams })).toBe(expected);
   });
+
+  test('scenario which testes the typescript types', () => {
+    // We are testing the typescript types here so a failure means
+    // typscript will complain about the following code.
+
+    interface DashboardPathParams {
+      id: number;
+    }
+    
+    interface DashboardQueryParams {
+      page: number;
+      query: string;
+    }
+
+    function defaultDashboardQueryParams(): DashboardQueryParams {
+      return {
+        page: 1,
+        query: ''
+      };
+    }
+
+    function toDashboard(
+      pathParams?: DashboardPathParams,
+      queryParams?: Partial<DashboardQueryParams>
+    ): Url {
+      return urlBuilder({
+        url: '/dashboard/:id',
+        pathParams,
+        queryParams,
+        defaultQueryParams: defaultDashboardQueryParams()
+      });
+    }
+
+    expect(toDashboard()).toBe('/dashboard/:id');
+    expect(toDashboard({ id: 42 })).toBe('/dashboard/42');
+    expect(toDashboard({ id: 42 }, { page: 1337})).toBe('/dashboard/42?page=1337');
+  })
 });


### PR DESCRIPTION
Before the type of the urlBuilder was:

```ts
export interface UrlBuilderOptions<QueryParams> {
  url: Url;
  pathParams?: QueryParams;
  queryParams?: QueryParams;
  defaultQueryParams?: QueryParams;
}
```

This is incorrect because `pathParams` is never the same as `queryParams`.

The correct type is:

```ts
export interface UrlBuilderOptions<PathParams, QueryParams> {
  url: Url;
  pathParams?: PathParams;
  queryParams?: QueryParams;
  defaultQueryParams?: QueryParams;
}
```

The PathParams should have its own generic to make this correct.

Appearently this is something that TypeScript `3.5.3` can pick up,
so bumpbed the version to it.

Also wrote a scenario test which makes sure that the TypeScript will
fail in the compile if this bug ever comes back.