### PR TITLE
Improvement: documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,3 +4,7 @@ baseurl: /mad-react-url/
 description: 'Utils for creating URLs for react based applications'
 plugins:
   - jekyll-remote-theme
+links:
+  - name: 'View on Github'
+    icon: 'https://unpkg.com/simple-icons@latest/icons/github.svg'
+    href: 'https://github.com/42BV/mad-react-url'

--- a/docs/guide/3. query params.md
+++ b/docs/guide/3. query params.md
@@ -56,10 +56,8 @@ export function defaultUserListQueryParams(): UserListQueryParams {
   By extending RouteComponentProps we get the standard props that
   react-router adds when the component in a route.
 */
-interface Props extends RouteComponentProps<UserListPathParams> {}
-
-export default function UserList(props: Props) {
-  const { location } = props;
+export default function UserList() {
+  const location = useLocation();
 
   const queryParams = useQueryParams({
     /* We give it the location which contains the raw query param string. */

--- a/docs/guide/4. basic example.md
+++ b/docs/guide/4. basic example.md
@@ -51,13 +51,10 @@ export function defaultDashboardQueryParams(): DashboardQueryParams {
   By extending RouteComponentProps we get the standard props that
   react-router adds when the component in a route.
 */
-interface Props extends RouteComponentProps<DashboardPathParams> {}
-
-export default function Dashboard(props: Props) {
-  const { match, location } = props;
-
-  /* The `id` is a string which can be found on the match. */
-  const id = match.params.id;
+export default function Dashboard() {
+  /* The `id` is a string which can be found on the params. */
+  const { id } = useParams<DashboardPathParams>();
+  const location = useLocation();
 
   const queryParams = useQueryParams({
     location,
@@ -91,6 +88,7 @@ export function toDashboard(pathParams: DashboardPathParams, queryParams?: Parti
 ### 4.1.2 via withQueryParams
 
 > We recommend using `useQueryParams` whenever possible.
+> This method only works with `Route` as defined from `react-router < 5.1.0`.
 
 ```tsx
 // Dashboard.tsx
@@ -187,7 +185,9 @@ export default function Routes() {
         <Link to={toDashboard({ id: 1 })}>Dashboard</Link>
 
         <Switch>
-          <Route exact path={DASHBOARD_URL} component={Dashboard} />
+          <Route exact path={DASHBOARD_URL}>
+            <Dashboard />
+          </Route>
         </Switch>
       </div>
     </BrowserRouter>


### PR DESCRIPTION
Updated the documentation to reflect `react-router > 5.1.0` changes.
This decouples functional components from the `RouteComponentProps`
interface, and favors hooks such as `useLocation` and `useParams`.