### PR TITLE
bug: Array parsing did not work when there was only one value in the …

### DIFF
--- a/tests/queryparams.test.ts
+++ b/tests/queryparams.test.ts
@@ -1,6 +1,5 @@
 import { queryParamsFromLocation, convertQueryParamsToConcreteType } from '../src/queryparams';
 
-
 describe('queryParamsFromLocation', () => {
   it('should know how to convert strings that start with a question mark', () => {
     const location = { search: '?query=hallo' };
@@ -93,6 +92,27 @@ describe('convertQueryParamsToConcreteType', () => {
       );
       expect(queryParams).toEqual({ sizes: ['medium', 'large', 'small'] });
     });
+
+    describe('when encountering a singular value', () => {
+      it('should convert to an array of strings when a singular string is given', () => {
+        const queryParams = convertQueryParamsToConcreteType({ sizes: 'large' }, { sizes: ['small'] }, 'AppComponent');
+        expect(queryParams).toEqual({ sizes: ['large'] });
+      });
+
+      it('should convert to an array of numbers when a singular number is given', () => {
+        const queryParams = convertQueryParamsToConcreteType({ numbers: '1' }, { numbers: [42] }, 'AppComponent');
+        expect(queryParams).toEqual({ numbers: [1] });
+      });
+
+      it('should convert to an array of booleans when a singular boolean is given', () => {
+        const queryParams = convertQueryParamsToConcreteType({ visible: 'true' }, { visible: [false] }, 'AppComponent');
+        expect(queryParams).toEqual({ visible: [true] });
+      });
+
+      it('should convert to an array of the singular value when an empty default is given', () => {
+        const queryParams = convertQueryParamsToConcreteType({ sizes: 'medium' }, { sizes: [] }, 'AppComponent');
+        expect(queryParams).toEqual({ sizes: ['medium'] });
+      });
+    });
   });
 });
-


### PR DESCRIPTION
…array.

When the query parameters were defined as such:

```ts
interface DashboardQueryParams {
  filters: string[];
}

export function defaultDashboardQueryParams(): DashboardQueryParams {
  return {
    filters: []
  };
}

```

And the query params are: `?filters=ALL` the result of getting the query
params via `queryParamsFromLocation` was:

```ts
{
  filters: "ALL"
}
```

Instead of the expected:

```ts
{
  filters: ["ALL"]
}
```

The reasons for is deceptively simple:  `querystring`'s `parse` only
creates arrays when it encounters a query string twice it returns
a singular value when only one value is in the array. For example:

`parse('?filters=GREEN&filters=RED')`

Becomes:

`{ filters: ['GREEN', 'RED'] }`

However there is one gotcha: it will only transform to an array
when it encounters mulptile values, so this:

`parse('?filters=ALL')`

Becomes:

`{ filters: 'ALL' }`

This is logical because how can `querystring` know it is an array at all?

The problem is on our end we checked if something is an array by checking
if the value form `querystring` is an array. This is not correct, we should
check if the default value is an array instead. Since the default value
ultimately should determine the type, which it does for everything else
except for the array check.

So now we check if the query param is an array by checking with the
default query params instead. Also when the actual query params is a
singlular value after the default query param has been identified as an
array, we convert that singular value to an array.

This way query parameters which are array's are properly parsed.

Closes: #17