### PR TITLE
fix: multiple optional empty path params didn't strip all ending slashes

### DIFF
--- a/src/pathParamsBuilder.ts
+++ b/src/pathParamsBuilder.ts
@@ -32,7 +32,7 @@ export function pathParamsBuilder(options: PathParamsBuilderOptions): Url {
     .map(part => processPart(part, pathParams))
     .join('/');
 
-  return stripEndingSlash(replacedUrl);
+  return stripEndingSlashes(replacedUrl);
 }
 
 // Take a part of the path and process it, when it is a path param
@@ -72,12 +72,6 @@ function pathParamToKey(pathParam: string): string {
   return pathParam.substring(1, end);
 }
 
-function stripEndingSlash(url: string): string {
-  const end = url.length - 1;
-
-  if (url[end] !== '/') {
-    return url;
-  }
-
-  return url.substring(0, end);
+function stripEndingSlashes(url: string): string {
+  return url.replace(/\/+$/, '');
 }

--- a/tests/pathParamsBuilder.test.ts
+++ b/tests/pathParamsBuilder.test.ts
@@ -37,6 +37,15 @@ describe('test pathParamsBuilder', () => {
     expect(generatedUrl).toBe('/users');
   });
 
+  test('with multiple optional path params missing at the end', () => {
+    const generatedUrl = pathParamsBuilder({
+      url: '/users/:id?/:action?/:subaction?',
+      pathParams: {},
+    });
+
+    expect(generatedUrl).toBe('/users');
+  });
+
   test('with some missing/extra params', () => {
     const generatedUrl = pathParamsBuilder({
       url: '/users/:id/edit/:idd/employee',


### PR DESCRIPTION
Calling `pathParamsBuilder` with multiple missing optional path params
like so:

```ts
const generatedUrl = pathParamsBuilder({
  url: '/users/:id?/:action?/:subaction?',
  pathParams: {},
});
```

Would result in `/users//` and not in the expected `/users`.

The reason for this is because the `stripEndingSlash` would only strip
the final slash, and not all ending slashes.

Renamed `stripEndingSlash` to `stripEndingSlashes` and replaced it with
a regex which removes all ending slashes.

Fixes #21