### PR TITLE
improvement: urlBuilder optional empty path parameters are now removed

### DIFF
--- a/docs/guide/2. defining urls.md
+++ b/docs/guide/2. defining urls.md
@@ -94,7 +94,84 @@ history.push(toUserEdit({ id: '42'}));
 
 It is important that the argument `pathParams` to the function `toUserEdit` is `required`. Once again, this ensures type safety.
 
-## 2.3 With query params
+## 2.3 With optional path params
+
+If the route has optional path params. Optional path params are not
+required for the route to activate. You can combine
+
+```tsx
+import { Url, urlBuilder } from '@42.nl/react-url';
+
+/* We recommend defining this type in the UserList component's file. */
+type UserListPathParams = {
+  tab?: 'all' | 'inactive' | 'active'; /* All path params are strings. */
+}
+
+/* This const should be used to define the `Route` */
+export const USER_LIST_URL = '/users/:action?';
+
+export function toUserList(
+  pathParams?: UserListPathParams, // The path params can be optional now
+): Url {
+  return urlBuilder({
+    url: USER_LIST_URL,
+    pathParams
+  });
+}
+
+/* To use it in react-router use the URL const */
+<Route path={USER_LIST_URL} component={UserList} />
+
+/* To use it to navigate to a route you can use it in a react-router Link: */
+<Link to={toUserList()}>/users</Link>
+
+/* The tab is optional but can be provided */
+<Link to={toUserList({ tab: 'all'})}>/users/all</Link>
+
+/* Or programmatically -> users/active */
+history.push(toUserEdit({tab: 'active'}));
+```
+
+## 2.4 With required path params and optional path params
+
+The route can also have both required path params and optional path
+params.
+
+```tsx
+import { Url, urlBuilder } from '@42.nl/react-url';
+
+/* We recommend defining this type in the UserList component's file. */
+type UserDetailPathParams = {
+  id: string; /* All path params are strings. */
+  mode?: 'view' | 'edit'; /* All path params are strings. */
+}
+
+/* This const should be used to define the `Route` */
+export const USER_DETAIL_URL = '/users/:id/:action?';
+
+export function toUserDetail(
+  pathParams: UserDetailPathParams,
+): Url {
+  return urlBuilder({
+    url: USER_DETAIL_URL,
+    pathParams
+  });
+}
+
+/* To use it in react-router use the URL const */
+<Route path={USER_DETAIL_URL} component={UserList} />
+
+/* To use it to navigate to a route you can use it in a react-router Link: */
+<Link to={toUserDetail({ id: '42'})}>/users/42</Link>
+
+/* The mode is optional but can be provided */
+<Link to={toUserDetail({ id: '42', mode: 'view'})}>/users/42/view</Link>
+
+/* Or programmatically -> users/42/edit */
+history.push(toUserEdit({ id: '42', mode: 'edit'}));
+```
+
+## 2.5 With query params
 
 If the route has query params:
 
@@ -158,7 +235,7 @@ toUsers({ page: 42, search: '' }); /* -> /users?page=42 */
 toUsers({ page: 1, search: 'answer' }); /* -> /users?answer=42 */
 ```
 
-## 2.4 With path params and query params
+## 2.6 With path params and query params
 
 If the route has both path parameters and query parameters:
 
@@ -206,5 +283,8 @@ export function toUserEdit(
 /* Or programmatically -> users/42/edit?modal=true */
 history.push(toUserEdit({id: '42'}, { modal: true }));
 ```
+
+Note: you can also define routes with required path params, optional
+path params, and query params.
 
 Now that we have setup URLs lets take a look at how query params work.

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,1 +1,4 @@
+/**
+ * Type alias for string which represents a url.
+ */
 export type Url = string;

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -10,22 +10,9 @@ export type UrlBuilderOptions<PathParams, QueryParams> = {
 };
 
 /**
- * Has two use cases:
- *
- * 1. Returns the abstract Url when only the `url` option key is
- *    provided. For example urlBuilder({ url: '/users/:id' }) returns.
- *
- * 2. Replaces all the matching keys in the path params in the url with the value,
- *    and adds all query params key value pairs as string key=value to the url minus
- *    all the key value matching in the defaultQueryParams
- *
- * The idea behind this is that `urlBuilder` can be used to either defined
- * urls for routes, and actually navigating to those routes.
- *
- * @example
- *  urlBuilder({ url: '/users/:id' })
- *
- *  results in: '/users/:id'
+ * Replaces all the matching keys in the path params in the url with the value,
+ * and adds all query params key value pairs as string key=value to the url minus
+ * all the key value matching in the defaultQueryParams.
  *
  * @example
  *  urlBuilder({
@@ -47,23 +34,23 @@ export type UrlBuilderOptions<PathParams, QueryParams> = {
  *
  * @param {String} options.url The url to be parsed
  * @param {Object} options.pathParams Consists of the matching key in the url to be replaced by the value.
- * @param {Object} options.queryParams
- * @param {Object} options.defaultQueryParams
+ * @param {Object} options.queryParams The query parameters for the url
+ * @param {Object} options.defaultQueryParams The default query parameters, the query params which match the defaults will be removed.
+ * @returns {String} The build fully built url
  */
 export function urlBuilder<PathParams, QueryParams>(
   options: UrlBuilderOptions<PathParams, QueryParams>
 ): Url {
-  const { url, pathParams, queryParams, defaultQueryParams } = options;
+  const {
+    url,
+    pathParams = {},
+    queryParams,
+    defaultQueryParams = {}
+  } = options;
 
-  // If we have no pathParams and queryParams return the abstract url.
-  if (!pathParams && !queryParams) {
-    return url;
-  }
+  const urlPath = pathParamsBuilder({ url, pathParams });
 
-  // @ts-expect-error The pathParams is really an object.
-  const urlPath = pathParams ? pathParamsBuilder({ url, pathParams }) : url;
-
-  if (queryParams && defaultQueryParams) {
+  if (queryParams) {
     return queryParamsBuilder({
       url: urlPath,
       queryParams,

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -7,6 +7,49 @@ export type Config<QueryParams> = {
   debugName?: string;
 };
 
+/**
+ * A hook which provides the query params from the react-router-dom's
+ * `Location.search` string as an actual typed object.
+ *
+ * Requires defaultQueryParameters to fill in the blanks when the
+ * query parameters are not in the url. This way you are guaranteed
+ * to always have values for your query parameters.
+ *
+ * It also uses the defaultQueryParameters to convert the query
+ * parameters (which all come out as strings) to the type of
+ * the defaultQueryParameter.
+ *
+ * @example
+ * type DashboardQueryParams = {
+ *   page: number;
+ *   query: string;
+ *   active: boolean;
+ * }
+ *
+ * export function defaultDashboardQueryParams(): DashboardQueryParams {
+ *   return {
+ *     page: 1,
+ *     query: '',
+ *     active: false,
+ *   };
+ * }
+ *
+ * function Dashboard() {
+ *   const location = useLocation();
+ *   const queryParams = useQueryParams({
+ *    location,
+ *    defaultQueryParams: defaultUserListQueryParams(),
+ *    debugName: 'Component',
+ *  });
+ * }
+ *
+ * At this point queryParams would be a DashboardQueryParams object.
+ *
+ * @param {String} options.location The Location object of react-router-dom which contains the query params in the search
+ * @param {Object} options.defaultQueryParams The default query parameters which will be used to fill in any blanks in the query params
+ * @param {Object} options.debugName The name which will be used for debugging.
+ * @returns {Object} The typed object representing the query params
+ */
 export function useQueryParams<QueryParams>({
   location,
   defaultQueryParams,

--- a/src/withQueryParams.tsx
+++ b/src/withQueryParams.tsx
@@ -32,8 +32,9 @@ export type WithQueryProps<QueryParams> = {
  *
  * Can also support arrays and convert to actual types as well.
  *
- * @param {String} options.url The url to be parsed
- * @param {Object} options.pathParams Consists of the matching key in the url to be replaced by the value.
+ * @param {React.ComponentType<P>} Component The react component which you want to encapsulate with the withQueryParams HoC
+ * @param {Object} defaultQueryParameters The default query parameters which will be used to fill in any blanks in the query params
+ * @returns {HoC} which provides the query params as a prop.
  */
 export const withQueryParams = <P extends Record<string, unknown>, QueryParams>(
   Component: React.ComponentType<P>,

--- a/tests/urlBuilder.test.ts
+++ b/tests/urlBuilder.test.ts
@@ -2,10 +2,16 @@ import { urlBuilder } from '../src/urlBuilder';
 import { Url } from '../src/models';
 
 describe('urlBuilder', () => {
-  it('should know how to return abstract urls', () => {
+  it('should when path param is not provided return as is', () => {
     const url = '/users/:id';
 
     expect(urlBuilder({ url })).toBe(url);
+  });
+
+  it('should when path param is not provided return as is, but remove optional path params', () => {
+    const url = '/users/:id/:action?';
+
+    expect(urlBuilder({ url })).toBe('/users/:id');
   });
 
   it('should know how to return full urls with paths params', () => {
@@ -17,10 +23,29 @@ describe('urlBuilder', () => {
     expect(urlBuilder({ url, pathParams })).toBe(expected);
   });
 
+  it('should know how to return full urls with paths params and optional path params', () => {
+    const url = '/users/:id/:action?';
+    const pathParams = { id: 891 };
+
+    const expected = '/users/891';
+
+    expect(urlBuilder({ url, pathParams })).toBe(expected);
+  });
+
   it('should know how to return urls with query params', () => {
     const url = '/users';
     const queryParams = { search: 'awesome', num: 23 };
-    const defaultQueryParams = {};
+    const defaultQueryParams = { num: 23 };
+
+    const expected = '/users?search=awesome';
+
+    expect(urlBuilder({ url, queryParams, defaultQueryParams })).toBe(expected);
+  });
+
+  it('should know how to return urls with query params with no default query params, and simply only use the query params then', () => {
+    const url = '/users';
+    const queryParams = { search: 'awesome', num: 23 };
+    const defaultQueryParams = undefined;
 
     const expected = '/users?num=23&search=awesome';
 


### PR DESCRIPTION
The `urlBuilder` had two use cases before:

1. Creating the urls for the route to consume
2. Creating urls for navigation

The first has now been completely removed from the jsdoc of urlBuilder.
We do not support url creation anymore for the router in the `urlBuilder`.

This is a breaking change and you should migrate away from the old
behavior. The old behavior was no longer documented since 2.3.0 already.
The breaking change is that optional path parameters are now removed by
default.

```ts
const url = urlBuilder({url: "/users/:id/:action?"})
// url is now `/users/:id` instead of `/users/:id/:actions?`
```

You should no longer use the a url function to create the path for a
Route:

```tsx
<Route path={toUserEdit()} component={UserEdit} />
``
But instead use a const url:

```tsx
<Route path={USER_EDIT_URL} component={UserEdit} />
``

Also improved the jsdoc for `withQueryParams` the parameters were not
properly documented. Added jsdocs documentation for `useQueryParams`.

Closes: #23